### PR TITLE
Add test for profiles without options

### DIFF
--- a/setupTests.js
+++ b/setupTests.js
@@ -225,11 +225,11 @@ window.profileList = [
     slug: "empty-options",
     description: "Profile with empty options",
     display_name: "Empty Options",
-    profile_options: {}
+    profile_options: {},
   },
   {
     slug: "no-options",
     description: "Profile with no options",
-    display_name: "No Options"
+    display_name: "No Options",
   },
 ];

--- a/setupTests.js
+++ b/setupTests.js
@@ -199,6 +199,7 @@ window.profileList = [
     slug: "custom",
   },
   {
+    slug: "build-custom-environment",
     description: "Dynamic Image building + unlisted choice",
     display_name: "Build custom environment",
     profile_options: {
@@ -219,5 +220,16 @@ window.profileList = [
         },
       },
     },
+  },
+  {
+    slug: "empty-options",
+    description: "Profile with empty options",
+    display_name: "Empty Options",
+    profile_options: {}
+  },
+  {
+    slug: "no-options",
+    description: "Profile with no options",
+    display_name: "No Options"
   },
 ];

--- a/src/ProfileForm.test.js
+++ b/src/ProfileForm.test.js
@@ -234,4 +234,22 @@ describe("Profile form with URL Params", () => {
     expect(screen.getByLabelText("Repository").value).toEqual("org/repo");
     expect(screen.getByLabelText("Git Ref").value).toEqual("v1.0");
   });
+
+  test("no-option profiles are rendered", () => {
+    render(
+      <SpawnerFormProvider>
+        <ProfileForm />
+      </SpawnerFormProvider>,
+    );
+
+    const empty = screen.queryByRole("radio", {
+      name: "Empty Options Profile with empty options",
+    });
+    expect(empty).toBeInTheDocument();
+
+    const noObject = screen.queryByRole("radio", {
+      name: "No Options Profile with no options",
+    });
+    expect(noObject).toBeInTheDocument();
+  });
 });

--- a/src/state.js
+++ b/src/state.js
@@ -5,6 +5,9 @@ export const SpawnerFormContext = createContext();
 
 function isDynamicImageProfile(profile) {
   const { profile_options } = profile;
+
+  if (!profile_options) return false;
+
   return Object.entries(profile_options).some(([key, option]) =>
     hasDynamicImageBuilding(key, option),
   );


### PR DESCRIPTION
Resolves #95 

Adds test to support profiles where `profile_options` is and empty object, and where `profile_options`  is not present. 