### PR TITLE
Specify terminal colors

### DIFF
--- a/src/ImageBuilder.jsx
+++ b/src/ImageBuilder.jsx
@@ -67,6 +67,7 @@ function ImageLogs({ setTerm, setFitAddon, name }) {
         rows: 1,
         // Increase scrollback since image builds can sometimes produce a ton of output
         scrollback: 10000,
+        // colors checked with the contrast checker at https://webaim.org/resources/contrastchecker/
         theme: {
           red: "\x1b[38;2;248;113;133m",
           green: "\x1b[38;2;134;239;172m",

--- a/src/ImageBuilder.jsx
+++ b/src/ImageBuilder.jsx
@@ -67,6 +67,14 @@ function ImageLogs({ setTerm, setFitAddon, name }) {
         rows: 1,
         // Increase scrollback since image builds can sometimes produce a ton of output
         scrollback: 10000,
+        theme: {
+          red: "\x1b[38;2;248;113;133m",
+          green: "\x1b[38;2;134;239;172m",
+          yellow: "\x1b[38;2;253;224;71m",
+          blue: "\x1b[38;2;147;197;253m",
+          magenta: "\x1b[38;2;249;168;212m",
+          cyan: "\x1b[38;2;103;232;249m",
+        }
       });
       const fitAddon = new FitAddon();
       term.loadAddon(fitAddon);


### PR DESCRIPTION
Resolves #55 

Specifies the colours in the Xterm theme. 

<img width="192" alt="Screenshot 2024-11-19 at 12 44 12" src="https://github.com/user-attachments/assets/76f95aac-fac9-41e5-ba02-48311136ab03">

I checked all colours used with the [WebAIM contrast checker](https://webaim.org/resources/contrastchecker/) to ensure color/background combinations are accessible. 