### PR TITLE
Display error summary

### DIFF
--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -197,6 +197,11 @@ export function ImageBuilder({ name, isActive }: IImageBuilder) {
         error={repoError}
         options={repositoryOptions}
         autoComplete="off"
+        validate={
+          isActive && {
+            required: "Provide the repository as the format 'organization/repository'.",
+          }
+        }
       />
 
       <Combobox
@@ -245,7 +250,7 @@ export function ImageBuilder({ name, isActive }: IImageBuilder) {
         <div className="profile-option-control-container">
           <ImageLogs setFitAddon={setFitAddon} setTerm={setTerm} name={name} />
           {customImageError && (
-            <div className="profile-option-control-error">
+            <div className="invalid-feedback d-block">
               {customImageError}
             </div>
           )}

--- a/src/ProfileForm.test.tsx
+++ b/src/ProfileForm.test.tsx
@@ -97,9 +97,11 @@ describe("Profile form", () => {
 
     const submitButton = screen.getByRole("button", { "name": "Start" });
     await user.click(submitButton);
-    expect(screen.getByText("Enter a value.")).toBeInTheDocument();
     await waitFor(() => expect(screen.getByText("Unable to start the server. The form is incomplete.")).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByRole("link", {"name": "Enter a value."})).toBeInTheDocument());
+    expect(screen.queryAllByText("Enter a value.").length).toEqual(2);
+
+    // Check that one of the errors is the link in the error summary.
+    expect(screen.getByRole("link", {"name": "Enter a value."})).toBeInTheDocument();
   });
 
   test("custom image field needs specific format", async () => {

--- a/src/ProfileForm.test.tsx
+++ b/src/ProfileForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach } from "@jest/globals";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ProfileForm from "./ProfileForm";
@@ -71,6 +71,35 @@ describe("Profile form", () => {
     await user.click(document.body);
 
     expect(screen.getByText("Enter a value.")).toBeInTheDocument();
+  });
+
+  test("shows error summary", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SpawnerFormProvider>
+        <FormCacheProvider>
+          <form>
+            <ProfileForm />
+          </form>
+        </FormCacheProvider>
+      </SpawnerFormProvider>,
+    );
+
+    const radio = screen.getByRole("radio", {
+      name: "CPU only No GPU, only CPU",
+    });
+    await user.click(radio);
+
+    const imageField = screen.getByLabelText("Image");
+    await user.click(imageField);
+    await user.click(screen.getByText("Specify an existing docker image"));
+
+    const submitButton = screen.getByRole("button", { "name": "Start" });
+    await user.click(submitButton);
+    expect(screen.getByText("Enter a value.")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("Unable to start the server. The form is incomplete.")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole("link", {"name": "Enter a value."})).toBeInTheDocument());
   });
 
   test("custom image field needs specific format", async () => {

--- a/src/components/form/Combobox.tsx
+++ b/src/components/form/Combobox.tsx
@@ -159,7 +159,7 @@ function Combobox(
         className={`form-control ${!inputHasVisualFocus ? "shadow-none" : ""} ${validateError || error ? "is-invalid" : ""} ${className}`}
         type="text"
         role="combobox"
-        aria-invalid={!!error}
+        aria-invalid={!!(validateError || error)}
         aria-autocomplete="list"
         aria-expanded={listBoxExpanded}
         aria-controls={listboxId}
@@ -175,6 +175,7 @@ function Combobox(
         onFocus={handleFocus}
         onBlur={handleBlur}
         onKeyDown={onKeyDown}
+        onInvalid={() => setTouched(true)}
         tabIndex={tabIndex}
         required={required}
         ref={fieldRef}

--- a/src/components/form/fields.tsx
+++ b/src/components/form/fields.tsx
@@ -49,7 +49,7 @@ export function Field({ id, label, hint, children, error }: IField) {
       </div>
       <div className="profile-option-control-container" style={{ position: "relative" }}>
         {children}
-        {error && <div className="invalid-feedback">{error}</div>}
+        {error && <div className="invalid-feedback d-block">{error}</div>}
         {hint && <div className="profile-option-control-hint">{hint}</div>}
       </div>
     </div>

--- a/src/form.css
+++ b/src/form.css
@@ -110,6 +110,17 @@
   margin-bottom: 2rem;
 }
 
+.form-errors {
+  border: 2px solid var(--bs-form-invalid-color);
+  margin: 1rem 0;
+  padding: 1rem;
+  border-radius: 5px;
+}
+
+.form-errors li {
+  margin-left: 1rem;
+}
+
 /* react-select styling */
 .react-select-item-container.react-select-item-menu-display.react-select-item-selected
   .react-select-item-description {

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -56,6 +56,7 @@ export const SpawnerFormProvider = ({ children }: PropsWithChildren) => {
       const profilesWithDynamicImageBuilding = profileList.filter(
         isDynamicImageProfile,
       );
+
       if (profilesWithDynamicImageBuilding.length > 1) {
         return "Unable to pre-select dynamic image building.";
       }


### PR DESCRIPTION
Ref https://github.com/2i2c-org/jupyterhub-fancy-profiles/issues/111

Instead of greying out the submit button (which is hard, because we validate the form on submit, so we need to allow a submit to validate), I propose to display an error summary above the submit button. The summary contains a linked list of all errors in the form. Clicking on a link the list will scroll to the error.

<img width="781" alt="Screenshot 2025-04-15 at 4 22 37 pm" src="https://github.com/user-attachments/assets/7eee7696-92ec-44a6-b280-493954cf3d51" />

/cc @wildintellect Would love to hear your thoughts on this solution.