### PR TITLE
Remove options

### DIFF
--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -123,7 +123,7 @@ export function ImageBuilder({ name, isActive }: IImageBuilder) {
   } = useContext(SpawnerFormContext);
   const { repo, repoId, repoFieldProps, repoError } =
     useRepositoryField(binderRepo);
-  const { getRepositoryOptions, getRefOptions, removeRefOption } = useFormCache();
+  const { getRepositoryOptions, getRefOptions, removeRefOption, removeRepositoryOption } = useFormCache();
 
   const [ref, setRef] = useState<string>(repoRef || "HEAD");
   const repoFieldRef = useRef<HTMLInputElement>();
@@ -197,6 +197,7 @@ export function ImageBuilder({ name, isActive }: IImageBuilder) {
         error={repoError}
         options={repositoryOptions}
         autoComplete="off"
+        onRemoveOption={(option) => removeRepositoryOption(name, option)}
       />
 
       <Combobox

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -123,7 +123,7 @@ export function ImageBuilder({ name, isActive }: IImageBuilder) {
   } = useContext(SpawnerFormContext);
   const { repo, repoId, repoFieldProps, repoError } =
     useRepositoryField(binderRepo);
-  const { getRepositoryOptions, getRefOptions } = useFormCache();
+  const { getRepositoryOptions, getRefOptions, removeRefOption } = useFormCache();
 
   const [ref, setRef] = useState<string>(repoRef || "HEAD");
   const repoFieldRef = useRef<HTMLInputElement>();
@@ -214,6 +214,9 @@ export function ImageBuilder({ name, isActive }: IImageBuilder) {
         tabIndex={isActive ? 0 : -1}
         options={refOptions}
         autoComplete="off"
+        onRemoveOption={(option) => {
+          removeRefOption(name, repoFieldProps.value, option);
+        }}
       />
 
       <div className="right-button">

--- a/src/ResourceSelect.tsx
+++ b/src/ResourceSelect.tsx
@@ -28,7 +28,7 @@ function ResourceSelect({
     customOptions,
   );
   const { profile: selectedProfile } = useContext(SpawnerFormContext);
-  const { getChoiceOptions } = useFormCache();
+  const { getChoiceOptions, removeChoiceOption } = useFormCache();
   const FIELD_ID = `profile-option-${profile}--${id}`;
   const FIELD_ID_UNLISTED = `${FIELD_ID}--unlisted-choice`;
 
@@ -81,6 +81,7 @@ function ResourceSelect({
           tabIndex={isActive ? 0 : -1}
           options={choiceOptions}
           autoComplete="off"
+          onRemoveOption={(option) => removeChoiceOption(FIELD_ID_UNLISTED, option)}
         />
       )}
       {!!selectedCustomOption && (

--- a/src/components/form/Combobox.tsx
+++ b/src/components/form/Combobox.tsx
@@ -199,11 +199,11 @@ function Combobox(
             id={`${listboxId}-${index}`}
             role="option"
             className={`d-flex gap-4 align-items-center list-group-item list-group-item-action ${index === selectedOptionIdx ? "active" : ""}`}
+            onMouseDown={(e) => e.preventDefault()} // Preventing default so the input doesn't loose focus
           >
             <span
               className="flex-grow-1"
               onClick={() => handleOptionClick(option)}
-              onMouseDown={(e) => e.preventDefault()} // Preventing default so the input doesn't loose focus
               style={{
                 cursor: "pointer",
               }}

--- a/src/components/form/Combobox.tsx
+++ b/src/components/form/Combobox.tsx
@@ -12,6 +12,7 @@ interface ICombobox extends React.InputHTMLAttributes<HTMLInputElement> {
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
   options: string[];
   validate?: TValidateConfig;
+  onRemoveOption?: (option: string) => void;
 }
 
 function setInputValue(input: HTMLInputElement, value: string) {
@@ -43,6 +44,7 @@ function Combobox(
     tabIndex,
     validate = {},
     className = "",
+    onRemoveOption,
     ...restProps
   }: ICombobox,
   ref?: React.MutableRefObject<HTMLInputElement>,
@@ -196,14 +198,30 @@ function Combobox(
             key={`${listboxId}-${option}`}
             id={`${listboxId}-${index}`}
             role="option"
-            className={`list-group-item list-group-item-action ${index === selectedOptionIdx ? "active" : ""}`}
-            onClick={() => handleOptionClick(option)}
-            onMouseDown={(e) => e.preventDefault()} // Preventing default so the input doesn't loose focus
-            style={{
-              cursor: "pointer",
-            }}
+            className={`d-flex gap-4 align-items-center list-group-item list-group-item-action ${index === selectedOptionIdx ? "active" : ""}`}
           >
-            {option}
+            <span
+              className="flex-grow-1"
+              onClick={() => handleOptionClick(option)}
+              onMouseDown={(e) => e.preventDefault()} // Preventing default so the input doesn't loose focus
+              style={{
+                cursor: "pointer",
+              }}
+            >
+              {option}
+            </span>
+            {onRemoveOption && (
+              <button
+                type="button"
+                className={`btn btn-link p-0 btn-sm ${index === selectedOptionIdx ? "text-white" : ""}`}
+                onClick={(e) => {
+                  e.preventDefault();
+                  onRemoveOption(option);
+                }}
+              >
+                Remove
+              </button>
+            )}
           </li>
         ))}
       </ul>

--- a/src/context/FormCache.tsx
+++ b/src/context/FormCache.tsx
@@ -13,6 +13,7 @@ export interface IFormCache {
   removeChoiceOption: (fieldName: string, choice: string) => void;
   getRepositoryOptions: (fieldName: string) => string[];
   getRefOptions: (fieldName: string, repoName?: string) => string[];
+  removeRefOption: (fieldName: string, repository: string, ref: string) => void;
   cacheRepositorySelection: (
     fieldName: string,
     repository: string,
@@ -81,7 +82,6 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
   };
 
   const removeChoiceOption = (fieldName: string, choice: string) => {
-    console.log(fieldName, choice);
     removeOption(
       "choices",
       {
@@ -131,6 +131,17 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
     [previousRepositories],
   );
 
+  const removeRefOption = (fieldName: string, repository: string, ref: string) => {
+    removeOption(
+      "repositories",
+      {
+        field_name: fieldName,
+        repository,
+        ref,
+      }
+    ).then(loadPreviousRepositories);
+  };
+
   useEffect(() => {
     // Retrieve previously used choices
     loadPreviousChoices();
@@ -143,7 +154,8 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
     getRepositoryOptions,
     getRefOptions,
     cacheRepositorySelection,
-    removeChoiceOption
+    removeChoiceOption,
+    removeRefOption
   };
 
   return (

--- a/src/context/FormCache.tsx
+++ b/src/context/FormCache.tsx
@@ -5,11 +5,12 @@ import {
   useEffect,
   useState,
 } from "react";
-import { cacheOption, getRecords } from "../utils/indexedDb";
+import { cacheOption, getRecords, removeOption } from "../utils/indexedDb";
 
 export interface IFormCache {
   getChoiceOptions: (fieldName: string) => string[];
   cacheChoiceOption: (fieldName: string, choice: string) => void;
+  removeChoiceOption: (fieldName: string, choice: string) => void;
   getRepositoryOptions: (fieldName: string) => string[];
   getRefOptions: (fieldName: string, repoName?: string) => string[];
   cacheRepositorySelection: (
@@ -79,6 +80,17 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
       .map(({ choice }) => choice);
   };
 
+  const removeChoiceOption = (fieldName: string, choice: string) => {
+    console.log(fieldName, choice);
+    removeOption(
+      "choices",
+      {
+        field_name: fieldName,
+        choice,
+      }
+    ).then(loadPreviousChoices);
+  };
+
   const getRepositoryOptions = useCallback(
     (fieldName: string) => {
       const options = previousRepositories
@@ -131,6 +143,7 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
     getRepositoryOptions,
     getRefOptions,
     cacheRepositorySelection,
+    removeChoiceOption
   };
 
   return (

--- a/src/context/FormCache.tsx
+++ b/src/context/FormCache.tsx
@@ -5,7 +5,7 @@ import {
   useEffect,
   useState,
 } from "react";
-import { cacheOption, getRecords, removeOption } from "../utils/indexedDb";
+import { cacheOption, getRecords, removeOption, removeRepository } from "../utils/indexedDb";
 
 export interface IFormCache {
   getChoiceOptions: (fieldName: string) => string[];
@@ -13,6 +13,7 @@ export interface IFormCache {
   removeChoiceOption: (fieldName: string, choice: string) => void;
   getRepositoryOptions: (fieldName: string) => string[];
   getRefOptions: (fieldName: string, repoName?: string) => string[];
+  removeRepositoryOption: (fieldName: string, repository: string) => void;
   removeRefOption: (fieldName: string, repository: string, ref: string) => void;
   cacheRepositorySelection: (
     fieldName: string,
@@ -142,6 +143,10 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
     ).then(loadPreviousRepositories);
   };
 
+  const removeRepositoryOption = (fieldName: string, repository: string) => {
+    removeRepository(fieldName, repository).then(loadPreviousRepositories);
+  };
+
   useEffect(() => {
     // Retrieve previously used choices
     loadPreviousChoices();
@@ -155,6 +160,7 @@ export const FormCacheProvider = ({ children }: PropsWithChildren) => {
     getRefOptions,
     cacheRepositorySelection,
     removeChoiceOption,
+    removeRepositoryOption,
     removeRefOption
   };
 

--- a/src/hooks/useFormCache.ts
+++ b/src/hooks/useFormCache.ts
@@ -9,6 +9,7 @@ function useFormCache(): IFormCache {
     getRefOptions,
     cacheRepositorySelection,
     removeChoiceOption,
+    removeRefOption,
   } = useContext(FormCacheContext) as IFormCache;
 
   return useMemo(
@@ -19,6 +20,7 @@ function useFormCache(): IFormCache {
       getRefOptions,
       cacheRepositorySelection,
       removeChoiceOption,
+      removeRefOption,
     }),
     [
       getChoiceOptions,
@@ -27,6 +29,7 @@ function useFormCache(): IFormCache {
       getRefOptions,
       cacheRepositorySelection,
       removeChoiceOption,
+      removeRefOption,
     ],
   );
 }

--- a/src/hooks/useFormCache.ts
+++ b/src/hooks/useFormCache.ts
@@ -8,6 +8,7 @@ function useFormCache(): IFormCache {
     getRepositoryOptions,
     getRefOptions,
     cacheRepositorySelection,
+    removeChoiceOption,
   } = useContext(FormCacheContext) as IFormCache;
 
   return useMemo(
@@ -17,6 +18,7 @@ function useFormCache(): IFormCache {
       getRepositoryOptions,
       getRefOptions,
       cacheRepositorySelection,
+      removeChoiceOption,
     }),
     [
       getChoiceOptions,
@@ -24,6 +26,7 @@ function useFormCache(): IFormCache {
       getRepositoryOptions,
       getRefOptions,
       cacheRepositorySelection,
+      removeChoiceOption,
     ],
   );
 }

--- a/src/hooks/useFormCache.ts
+++ b/src/hooks/useFormCache.ts
@@ -9,6 +9,7 @@ function useFormCache(): IFormCache {
     getRefOptions,
     cacheRepositorySelection,
     removeChoiceOption,
+    removeRepositoryOption,
     removeRefOption,
   } = useContext(FormCacheContext) as IFormCache;
 
@@ -20,6 +21,7 @@ function useFormCache(): IFormCache {
       getRefOptions,
       cacheRepositorySelection,
       removeChoiceOption,
+      removeRepositoryOption,
       removeRefOption,
     }),
     [
@@ -29,6 +31,7 @@ function useFormCache(): IFormCache {
       getRefOptions,
       cacheRepositorySelection,
       removeChoiceOption,
+      removeRepositoryOption,
       removeRefOption,
     ],
   );


### PR DESCRIPTION
Implements #110 Enables removing options from the cache

- Extend indexedDB module with two functions
  - `removeOption` is a generic function to remove any option from the index using the store configuration provided
  - `removeRepository` addresses the special case of removing repos as we need to find all the records for a field-repo combination and delete all the rows
- Adds new index to indexedDb, which we use to find repository records
- Adds new functions to the `FormCache` context, to remove repositories, refs and image options
- Extend `Combobox` with the optional `onRemoveOption`, which we use to wire the remove functions to the UI. If `onRemoveOption ` is present, each option will display a "remove" link. 