### PR TITLE
Start image build on Enter

### DIFF
--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useContext, useMemo } from "react";
+import { useEffect, useState, useRef, useContext, useMemo, KeyboardEventHandler } from "react";
 import { type Terminal } from "xterm";
 import { type FitAddon } from "xterm-addon-fit";
 
@@ -177,6 +177,14 @@ export function ImageBuilder({ name, isActive }: IImageBuilder) {
       .finally(() => setIsBuildingImage(false));
   };
 
+  const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      (e.target as HTMLInputElement).blur();
+      handleBuildStart();
+    }
+  };
+
   // We render everything, but only toggle visibility based on wether we are being
   // shown or hidden. This provides for more DOM stability, and also allows the image
   // to continue being built evn if the user moves away elsewhere. When hidden, we just
@@ -202,6 +210,7 @@ export function ImageBuilder({ name, isActive }: IImageBuilder) {
             required: "Provide the repository as the format 'organization/repository'.",
           }
         }
+        onKeyDown={handleKeyDown}
       />
 
       <Combobox

--- a/src/components/form/Combobox.tsx
+++ b/src/components/form/Combobox.tsx
@@ -39,6 +39,7 @@ function Combobox(
     value,
     onChange,
     onBlur,
+    onKeyDown,
     options,
     tabIndex,
     validate = {},
@@ -78,7 +79,7 @@ function Combobox(
     setSelectedOptionIdx(undefined);
   };
 
-  const onKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
+  const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
     switch (event.key) {
       case "Down":
       case "ArrowDown":
@@ -110,6 +111,9 @@ function Combobox(
         event.preventDefault(); // Prevent form submit
         if (selectedOptionIdx !== undefined) {
           setInputValue(fieldRef.current, displayOptions[selectedOptionIdx]);
+        }
+        if (listBoxExpanded && inputHasVisualFocus) {
+          onKeyDown(event);
         }
         setInputHasVisualFocus(true);
         setListBoxExpanded(false);
@@ -174,7 +178,7 @@ function Combobox(
         onChange={onChange}
         onFocus={handleFocus}
         onBlur={handleBlur}
-        onKeyDown={onKeyDown}
+        onKeyDown={handleKeyDown}
         onInvalid={() => setTouched(true)}
         tabIndex={tabIndex}
         required={required}


### PR DESCRIPTION
Ref [#62](https://github.com/2i2c-org/jupyterhub-fancy-profiles/issues/62)

Since the introduction of cached-value dropdowns, the originally reported error won't occur any more because we're intercepting the `keydown` event for all comboboxes, and handling the `Enter` input. 

In this PR, I'm adding changes so the image build does start if:

- The Enter key is pressed, and
- we're currently not focussing on the drop down
- all image-build related fields are valid