### PR TITLE
add auth token to Binder building request, allowing us to enable auth on Binderhub

### DIFF
--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -20,10 +20,14 @@ async function buildImage(
     "/services/binder/build/",
     window.location.origin,
   );
+  // Pass JupyterHub authentication token to Binderhub
+  const headers = {
+    Authorization: `token ${window.jupyter.token}`
+  };
   const image = new BinderRepository(
     providerSpec,
     buildEndPointURL,
-    null,
+    headers,
     true,
   );
   // Clear the last line written, so we start from scratch

--- a/src/types/jupyterhub.d.ts
+++ b/src/types/jupyterhub.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for JupyterHub window extensions
+interface JupyterHub {
+  token: string;
+  user: string;
+  base_url: string;
+  prefix: string;
+  version: string;
+}
+
+interface Window {
+  jupyter: JupyterHub;
+}


### PR DESCRIPTION
Fixes #114 

Reads the token from the global JS scope, if available, and passes it as an Authorization header to Binderhub.