### PR TITLE
Fill form from URL query parameters

### DIFF
--- a/setupTests.js
+++ b/setupTests.js
@@ -18,6 +18,30 @@ Object.defineProperty(window, "matchMedia", {
   })),
 });
 
+// Mock the IntersectionObserver, see https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
+export class IntersectionObserver {
+  root = null;
+  rootMargin = "";
+  thresholds = [];
+
+  disconnect() {
+    return null;
+  }
+
+  observe() {
+    return null;
+  }
+
+  takeRecords() {
+    return [];
+  }
+
+  unobserve() {
+    return null;
+  }
+}
+window.IntersectionObserver = IntersectionObserver;
+
 window.profileList = [
   {
     slug: "cpu",

--- a/src/ImageBuilder.test.tsx
+++ b/src/ImageBuilder.test.tsx
@@ -1,21 +1,14 @@
 import { expect, test } from "@jest/globals";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ProfileForm from "./ProfileForm";
-import { SpawnerFormProvider } from "./state";
-import { FormCacheProvider } from "./context/FormCache";
+import renderWithContext from "./test/renderWithContext";
 
 test("select repository by org/repo", async () => {
   const user = userEvent.setup();
 
-  render(
-    <SpawnerFormProvider>
-      <FormCacheProvider>
-        <ProfileForm />
-      </FormCacheProvider>
-    </SpawnerFormProvider>,
-  );
+  renderWithContext(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -40,13 +33,7 @@ test("select repository by org/repo", async () => {
 test("select repository by https://github.com/org/repo", async () => {
   const user = userEvent.setup();
 
-  render(
-    <SpawnerFormProvider>
-      <FormCacheProvider>
-        <ProfileForm />
-      </FormCacheProvider>
-    </SpawnerFormProvider>,
-  );
+  renderWithContext(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -71,13 +58,7 @@ test("select repository by https://github.com/org/repo", async () => {
 test("select repository by https://www.github.com/org/repo", async () => {
   const user = userEvent.setup();
 
-  render(
-    <SpawnerFormProvider>
-      <FormCacheProvider>
-        <ProfileForm />
-      </FormCacheProvider>
-    </SpawnerFormProvider>,
-  );
+  renderWithContext(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -102,13 +83,7 @@ test("select repository by https://www.github.com/org/repo", async () => {
 test("select repository by github.com/org/repo", async () => {
   const user = userEvent.setup();
 
-  render(
-    <SpawnerFormProvider>
-      <FormCacheProvider>
-        <ProfileForm />
-      </FormCacheProvider>
-    </SpawnerFormProvider>,
-  );
+  renderWithContext(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -133,13 +108,7 @@ test("select repository by github.com/org/repo", async () => {
 test("select repository by www.github.com/org/repo", async () => {
   const user = userEvent.setup();
 
-  render(
-    <SpawnerFormProvider>
-      <FormCacheProvider>
-        <ProfileForm />
-      </FormCacheProvider>
-    </SpawnerFormProvider>,
-  );
+  renderWithContext(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -163,13 +132,7 @@ test("select repository by www.github.com/org/repo", async () => {
 test("invalid org/repo string (not matching pattern)", async () => {
   const user = userEvent.setup();
 
-  render(
-    <SpawnerFormProvider>
-      <FormCacheProvider>
-        <ProfileForm />
-      </FormCacheProvider>
-    </SpawnerFormProvider>,
-  );
+  renderWithContext(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -194,13 +157,7 @@ test("invalid org/repo string (not matching pattern)", async () => {
 test("invalid org/repo string (wrong base URL)", async () => {
   const user = userEvent.setup();
 
-  render(
-    <SpawnerFormProvider>
-      <FormCacheProvider>
-        <ProfileForm />
-      </FormCacheProvider>
-    </SpawnerFormProvider>,
-  );
+  renderWithContext(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -225,13 +182,7 @@ test("invalid org/repo string (wrong base URL)", async () => {
 test("no org/repo provided", async () => {
   const user = userEvent.setup();
 
-  render(
-    <SpawnerFormProvider>
-      <FormCacheProvider>
-        <ProfileForm />
-      </FormCacheProvider>
-    </SpawnerFormProvider>,
-  );
+  renderWithContext(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });
@@ -253,13 +204,7 @@ test("no org/repo provided", async () => {
 test("no branch selected", async () => {
   const user = userEvent.setup();
 
-  render(
-    <SpawnerFormProvider>
-      <FormCacheProvider>
-        <ProfileForm />
-      </FormCacheProvider>
-    </SpawnerFormProvider>,
-  );
+  renderWithContext(<ProfileForm />);
   const radio = screen.getByRole("radio", {
     name: "CPU only No GPU, only CPU",
   });

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -116,11 +116,8 @@ interface IImageBuilder {
 }
 
 export function ImageBuilder({ name, isActive }: IImageBuilder) {
-  const {
-    binderRepo,
-    ref: repoRef,
-    setCustomOption,
-  } = useContext(SpawnerFormContext);
+  const { urlSearchParams } = useContext(SpawnerFormContext);
+  const { binderRepo, ref: repoRef } = urlSearchParams;
   const { repo, repoId, repoFieldProps, repoError } =
     useRepositoryField(binderRepo);
   const { getRepositoryOptions, getRefOptions, removeRefOption, removeRepositoryOption } = useFormCache();
@@ -145,12 +142,6 @@ export function ImageBuilder({ name, isActive }: IImageBuilder) {
   useEffect(() => {
     if (!isActive) setCustomImageError("");
   }, [isActive]);
-
-  useEffect(() => {
-    if (setCustomOption) {
-      repoFieldRef.current.setAttribute("value", binderRepo);
-    }
-  }, [binderRepo, repoRef, setCustomOption]);
 
   const handleBuildStart = async () => {
     if (repoFieldRef.current && !repo) {

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -2,11 +2,11 @@ import { useEffect, useState, useRef, useContext, useMemo, KeyboardEventHandler 
 import { type Terminal } from "xterm";
 import { type FitAddon } from "xterm-addon-fit";
 
-import { SpawnerFormContext } from "./state";
 import useRepositoryField from "./hooks/useRepositoryField";
 import Combobox from "./components/form/Combobox";
 import useFormCache from "./hooks/useFormCache";
 import { PermalinkContext } from "./context/Permalink";
+import { ICustomOptionProps } from "./types/fields";
 
 async function buildImage(
   repo: string,
@@ -111,16 +111,11 @@ function ImageLogs({ setTerm, setFitAddon, name }: IImageLogs) {
   );
 }
 
-interface IImageBuilder {
-  name: string;
-  isActive: boolean;
-}
+export function ImageBuilder({ name, isActive, optionKey }: ICustomOptionProps) {
+  const { setPermalinkValue, permalinkValues } = useContext(PermalinkContext);
 
-export function ImageBuilder({ name, isActive }: IImageBuilder) {
-  const { urlSearchParams } = useContext(SpawnerFormContext);
-  const { setPermalinkValue } = useContext(PermalinkContext);
-
-  const { binderRepo, ref: repoRef } = urlSearchParams;
+  const repoRef = permalinkValues[`${optionKey}:ref`];
+  const binderRepo= permalinkValues[`${optionKey}:binderRepo`];
   const { repo, repoId, repoFieldProps, repoError } =
     useRepositoryField(binderRepo);
   const { getRepositoryOptions, getRefOptions, removeRefOption, removeRepositoryOption } = useFormCache();
@@ -147,9 +142,9 @@ export function ImageBuilder({ name, isActive }: IImageBuilder) {
   }, [isActive]);
 
   if (isActive) {
-    setPermalinkValue("binderProvider", "gh");
-    setPermalinkValue("binderRepo", repoId);
-    setPermalinkValue("ref", ref);
+    setPermalinkValue(`${optionKey}:binderProvider`, "gh");
+    setPermalinkValue(`${optionKey}:binderRepo`, repoId);
+    setPermalinkValue(`${optionKey}:ref`, ref);
   }
 
   const handleBuildStart = async () => {

--- a/src/ImageBuilder.tsx
+++ b/src/ImageBuilder.tsx
@@ -6,6 +6,7 @@ import { SpawnerFormContext } from "./state";
 import useRepositoryField from "./hooks/useRepositoryField";
 import Combobox from "./components/form/Combobox";
 import useFormCache from "./hooks/useFormCache";
+import { PermalinkContext } from "./context/Permalink";
 
 async function buildImage(
   repo: string,
@@ -117,6 +118,8 @@ interface IImageBuilder {
 
 export function ImageBuilder({ name, isActive }: IImageBuilder) {
   const { urlSearchParams } = useContext(SpawnerFormContext);
+  const { setPermalinkValue } = useContext(PermalinkContext);
+
   const { binderRepo, ref: repoRef } = urlSearchParams;
   const { repo, repoId, repoFieldProps, repoError } =
     useRepositoryField(binderRepo);
@@ -142,6 +145,12 @@ export function ImageBuilder({ name, isActive }: IImageBuilder) {
   useEffect(() => {
     if (!isActive) setCustomImageError("");
   }, [isActive]);
+
+  if (isActive) {
+    setPermalinkValue("binderProvider", "gh");
+    setPermalinkValue("binderRepo", repoId);
+    setPermalinkValue("ref", ref);
+  }
 
   const handleBuildStart = async () => {
     if (repoFieldRef.current && !repo) {

--- a/src/ProfileForm.test.tsx
+++ b/src/ProfileForm.test.tsx
@@ -1,20 +1,14 @@
 import { describe, expect, test, beforeEach } from "@jest/globals";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ProfileForm from "./ProfileForm";
-import { SpawnerFormProvider } from "./state";
-import { FormCacheProvider } from "./context/FormCache";
+import renderWithContext from "./test/renderWithContext";
+
 
 describe("Profile form", () => {
   test("image and resource fields initially not tabable", async () => {
-    render(
-      <SpawnerFormProvider>
-        <FormCacheProvider>
-          <ProfileForm />
-        </FormCacheProvider>
-      </SpawnerFormProvider>,
-    );
+    renderWithContext(<ProfileForm />);
 
     const imageField = screen.getByLabelText("Image");
     expect(imageField.tabIndex).toEqual(-1);
@@ -26,13 +20,7 @@ describe("Profile form", () => {
   test("image and resource fields tabable", async () => {
     const user = userEvent.setup();
 
-    render(
-      <SpawnerFormProvider>
-        <FormCacheProvider>
-          <ProfileForm />
-        </FormCacheProvider>
-      </SpawnerFormProvider>,
-    );
+    renderWithContext(<ProfileForm />);
 
     const radio = screen.getByRole("radio", {
       name: "CPU only No GPU, only CPU",
@@ -49,13 +37,7 @@ describe("Profile form", () => {
   test("custom image field is required", async () => {
     const user = userEvent.setup();
 
-    render(
-      <SpawnerFormProvider>
-        <FormCacheProvider>
-          <ProfileForm />
-        </FormCacheProvider>
-      </SpawnerFormProvider>,
-    );
+    renderWithContext(<ProfileForm />);
 
     const radio = screen.getByRole("radio", {
       name: "CPU only No GPU, only CPU",
@@ -76,14 +58,10 @@ describe("Profile form", () => {
   test("shows error summary", async () => {
     const user = userEvent.setup();
 
-    render(
-      <SpawnerFormProvider>
-        <FormCacheProvider>
-          <form>
-            <ProfileForm />
-          </form>
-        </FormCacheProvider>
-      </SpawnerFormProvider>,
+    renderWithContext(
+      <form>
+        <ProfileForm />
+      </form>
     );
 
     const radio = screen.getByRole("radio", {
@@ -107,13 +85,7 @@ describe("Profile form", () => {
   test("custom image field needs specific format", async () => {
     const user = userEvent.setup();
 
-    render(
-      <SpawnerFormProvider>
-        <FormCacheProvider>
-          <ProfileForm />
-        </FormCacheProvider>
-      </SpawnerFormProvider>,
-    );
+    renderWithContext(<ProfileForm />);
 
     const radio = screen.getByRole("radio", {
       name: "CPU only No GPU, only CPU",
@@ -138,13 +110,7 @@ describe("Profile form", () => {
   test("custom image field accepts specific format", async () => {
     const user = userEvent.setup();
 
-    render(
-      <SpawnerFormProvider>
-        <FormCacheProvider>
-          <ProfileForm />
-        </FormCacheProvider>
-      </SpawnerFormProvider>,
-    );
+    renderWithContext(<ProfileForm />);
 
     const radio = screen.getByRole("radio", {
       name: "CPU only No GPU, only CPU",
@@ -170,13 +136,7 @@ describe("Profile form", () => {
   test("Multiple profiles renders", async () => {
     const user = userEvent.setup();
 
-    render(
-      <SpawnerFormProvider>
-        <FormCacheProvider>
-          <ProfileForm />
-        </FormCacheProvider>
-      </SpawnerFormProvider>,
-    );
+    renderWithContext(<ProfileForm />);
 
     const radio = screen.getByRole("radio", {
       name: "GPU Nvidia Tesla T4 GPU",
@@ -208,26 +168,14 @@ describe("Profile form", () => {
   });
 
   test("select with no options should not render", () => {
-    render(
-      <SpawnerFormProvider>
-        <FormCacheProvider>
-          <ProfileForm />
-        </FormCacheProvider>
-      </SpawnerFormProvider>,
-    );
+    renderWithContext(<ProfileForm />);
     expect(
       screen.queryByLabelText("Image - No options"),
     ).not.toBeInTheDocument();
   });
 
   test("profile marked as default is selected by default", () => {
-    const { container } = render(
-      <SpawnerFormProvider>
-        <FormCacheProvider>
-          <ProfileForm />
-        </FormCacheProvider>
-      </SpawnerFormProvider>,
-    );
+    const { container } = renderWithContext(<ProfileForm />);
     const hiddenRadio = container.querySelector("[name='profile']");
     expect((hiddenRadio as HTMLInputElement).value).toEqual("custom");
     const defaultRadio = screen.getByRole("radio", {
@@ -243,13 +191,7 @@ describe("Profile form", () => {
   test("having dynamic_image_building enabled and no other choices shows dropdown", async () => {
     const user = userEvent.setup();
 
-    render(
-      <SpawnerFormProvider>
-        <FormCacheProvider>
-          <ProfileForm />
-        </FormCacheProvider>
-      </SpawnerFormProvider>,
-    );
+    renderWithContext(<ProfileForm />);
     const select = screen.getByLabelText("Image - dynamic image building");
     await user.click(select);
     expect(screen.getByText("Build your own image")).toBeInTheDocument();
@@ -261,7 +203,7 @@ describe("Profile form with URL Params", () => {
   beforeEach(() => {
     const location = {
       ...window.location,
-      search: "?binderProvider=gh&binderRepo=org/repo&ref=v1.0",
+      search: "?fancy-forms-config=%7B%22profile%22%3A%22build-custom-environment%22%2C%22image%22%3A%22--extra-selectable-item%22%2C%22image%3Aunlisted_choice%22%3A%22%22%2C%22image%3AbinderProvider%22%3A%22gh%22%2C%22image%3AbinderRepo%22%3A%22org%2Frepo%22%2C%22image%3Aref%22%3A%22v1.0%22%7D",
     };
     Object.defineProperty(window, "location", {
       writable: true,
@@ -270,13 +212,7 @@ describe("Profile form with URL Params", () => {
   });
 
   test("preselects values", async () => {
-    render(
-      <SpawnerFormProvider>
-        <FormCacheProvider>
-          <ProfileForm />
-        </FormCacheProvider>
-      </SpawnerFormProvider>,
-    );
+    renderWithContext(<ProfileForm />);
 
     const radio = screen.getByRole("radio", {
       name: "Build custom environment Dynamic Image building + unlisted choice",
@@ -292,13 +228,7 @@ describe("Profile form with URL Params", () => {
   });
 
   test("no-option profiles are rendered", () => {
-    render(
-      <SpawnerFormProvider>
-        <FormCacheProvider>
-          <ProfileForm />
-        </FormCacheProvider>
-      </SpawnerFormProvider>,
-    );
+    renderWithContext(<ProfileForm />);
 
     const empty = screen.queryByRole("radio", {
       name: "Empty Options Profile with empty options",

--- a/src/ProfileForm.test.tsx
+++ b/src/ProfileForm.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeEach } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 

--- a/src/ProfileForm.test.tsx
+++ b/src/ProfileForm.test.tsx
@@ -197,6 +197,21 @@ describe("Profile form", () => {
     expect(screen.getByText("Build your own image")).toBeInTheDocument();
     expect(screen.getAllByText("Other...").length).toEqual(2); // There are two selects with the "Other..." label defined
   });
+
+  test("copy permalink to clipboard", async () => {
+    const user = userEvent.setup();
+
+    renderWithContext(<ProfileForm />);
+    const radio = screen.getByRole("radio", {
+      name: "GPU Nvidia Tesla T4 GPU",
+    });
+    await user.click(radio);
+    await user.click(screen.getByRole("button", {name: "Permalink"}));
+
+    const clipboardText = await navigator.clipboard.readText();
+
+    expect(clipboardText).toBe("http://localhost/?fancy-forms-config=%7B%22profile%22%3A%22gpu%22%2C%22image%22%3A%22geospatial%22%2C%22image%3Aunlisted_choice%22%3A%22%22%2C%22resources%22%3A%22mem_2_7%22%2C%22resources%3Aunlisted_choice%22%3A%22%22%7D");
+  });
 });
 
 describe("Profile form with URL Params", () => {

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -10,6 +10,7 @@ import "./form.css";
 import { SpawnerFormContext } from "./state";
 import { ProfileOptions } from "./ProfileOptions";
 import useFormCache from "./hooks/useFormCache";
+import { PermalinkContext } from "./context/Permalink";
 
 /**
  * Generates the *contents* of the form shown in the profile selection page
@@ -24,6 +25,7 @@ function Form() {
     setProfile,
     profileList
   } = useContext(SpawnerFormContext);
+  const { copyPermalink, setPermalinkValue } = useContext(PermalinkContext);
   const [profileError, setProfileError] = useState("");
   const [formErrors, setFormErrors] = useState<Element[]>([]);
   const { cacheChoiceOption, cacheRepositorySelection } = useFormCache();
@@ -38,7 +40,6 @@ function Form() {
 
     // prevent form submit
     if (!formIsValid) {
-
       setTimeout(() => {
         // Timeout here so we can collect the errors after the errors are rendered on the page
         const errors = form.getElementsByClassName("invalid-feedback");
@@ -104,6 +105,7 @@ function Form() {
             }`}
             onClick={() => {
               setProfile(slug);
+              setPermalinkValue("profile", slug);
             }}
           >
             {profileList.length > 1 && (
@@ -119,12 +121,19 @@ function Form() {
               />
             )}
             <div className="profile-select-body">
-              <div
-                id={`profile-option-${slug}-label`}
-                className="profile-select-label"
-              >
-                <h2>{display_name}</h2>
-                <p>{description}</p>
+              <div className="d-flex align-items-start">
+                <div
+                  id={`profile-option-${slug}-label`}
+                  className="profile-select-label flex-grow-1"
+                >
+                  <h2>{display_name}</h2>
+                  <p>{description}</p>
+                </div>
+                {selectedProfile?.slug === slug && (
+                  <button type="button" className="btn btn-link p-0" onClick={copyPermalink}>
+                    Permalink
+                  </button>
+                )}
               </div>
 
               {profile_options && (

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -27,7 +27,7 @@ function Form() {
     setProfile,
     profileList
   } = useContext(SpawnerFormContext);
-  const { permalinkValues, setPermalinkValue } = useContext(PermalinkContext);
+  const { permalinkValues, setPermalinkValue, permalinkParseError } = useContext(PermalinkContext);
   const [profileError, setProfileError] = useState("");
   const [formErrors, setFormErrors] = useState<Element[]>([]);
   const { cacheChoiceOption, cacheRepositorySelection } = useFormCache();
@@ -109,6 +109,7 @@ function Form() {
       aria-label="Select profile"
       aria-description="First, select the profile; second, configure the options for the selected profile."
     >
+      {permalinkParseError && <div className="alert alert-warning">Unable to parse permalink configuration.</div>}
       <input
         type="radio"
         className="hidden"

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -2,6 +2,7 @@ import {
   ChangeEventHandler,
   MouseEventHandler,
   useContext,
+  useEffect,
   useState,
 } from "react";
 import "../node_modules/xterm/css/xterm.css";
@@ -26,7 +27,7 @@ function Form() {
     setProfile,
     profileList
   } = useContext(SpawnerFormContext);
-  const { setPermalinkValue } = useContext(PermalinkContext);
+  const { permalinkValues, setPermalinkValue } = useContext(PermalinkContext);
   const [profileError, setProfileError] = useState("");
   const [formErrors, setFormErrors] = useState<Element[]>([]);
   const { cacheChoiceOption, cacheRepositorySelection } = useFormCache();
@@ -83,6 +84,26 @@ function Form() {
     setProfileError("");
   };
 
+  useEffect(() => {
+    // scroll the selected profile into view
+    if (permalinkValues.profile) {
+      const targetElement = document.getElementById(`profile-${permalinkValues.profile}`);
+      const observer = new IntersectionObserver((e) => {
+        if (e.length > 0 && !e[0].isIntersecting) {
+          // scroll the element into if not fully visible
+          targetElement.scrollIntoView();
+        }
+        // Disconnecting the oberserver, we only want to scroll once
+        observer.disconnect();
+      }, {
+        root: null,
+        rootMargin: "0px",
+        threshold: 1, // we want the element to be fully visible
+      });
+      observer.observe(targetElement);
+    }
+  }, [permalinkValues.profile]);
+
   return (
     <fieldset
       aria-label="Select profile"
@@ -101,6 +122,7 @@ function Form() {
 
         return (
           <div
+            id={`profile-${slug}`}
             key={slug}
             className={`profile-select ${
               selectedProfile?.slug === slug ? "selected-profile" : ""

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -11,6 +11,7 @@ import { SpawnerFormContext } from "./state";
 import { ProfileOptions } from "./ProfileOptions";
 import useFormCache from "./hooks/useFormCache";
 import { PermalinkContext } from "./context/Permalink";
+import Permalink from "./components/Permalink";
 
 /**
  * Generates the *contents* of the form shown in the profile selection page
@@ -25,7 +26,7 @@ function Form() {
     setProfile,
     profileList
   } = useContext(SpawnerFormContext);
-  const { copyPermalink, setPermalinkValue } = useContext(PermalinkContext);
+  const { setPermalinkValue } = useContext(PermalinkContext);
   const [profileError, setProfileError] = useState("");
   const [formErrors, setFormErrors] = useState<Element[]>([]);
   const { cacheChoiceOption, cacheRepositorySelection } = useFormCache();
@@ -129,11 +130,7 @@ function Form() {
                   <h2>{display_name}</h2>
                   <p>{description}</p>
                 </div>
-                {selectedProfile?.slug === slug && (
-                  <button type="button" className="btn btn-link p-0" onClick={copyPermalink}>
-                    Permalink
-                  </button>
-                )}
+                {selectedProfile?.slug === slug && <Permalink />}
               </div>
 
               {profile_options && (

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -79,6 +79,7 @@ function Form() {
   const handleProfileSelect: ChangeEventHandler<HTMLInputElement> = (e) => {
     const slug = e.target.value;
     setProfile(slug);
+    setPermalinkValue("profile", slug);
     setProfileError("");
   };
 

--- a/src/ProfileForm.tsx
+++ b/src/ProfileForm.tsx
@@ -22,8 +22,7 @@ function Form() {
   const {
     profile: selectedProfile,
     setProfile,
-    profileList,
-    paramsError,
+    profileList
   } = useContext(SpawnerFormContext);
   const [profileError, setProfileError] = useState("");
   const [formErrors, setFormErrors] = useState<Element[]>([]);
@@ -86,7 +85,6 @@ function Form() {
       aria-label="Select profile"
       aria-description="First, select the profile; second, configure the options for the selected profile."
     >
-      {paramsError && <div className="profile-form-warning">{paramsError}</div>}
       <input
         type="radio"
         className="hidden"

--- a/src/ResourceSelect.tsx
+++ b/src/ResourceSelect.tsx
@@ -27,17 +27,17 @@ function ResourceSelect({
     config,
     customOptions,
   );
-  const { profile: selectedProfile, urlSearchParams } = useContext(SpawnerFormContext);
-  const { setPermalinkValue } = useContext(PermalinkContext);
+  const { profile: selectedProfile } = useContext(SpawnerFormContext);
+  const { setPermalinkValue, permalinkValues } = useContext(PermalinkContext);
   const { getChoiceOptions, removeChoiceOption } = useFormCache();
   const FIELD_ID = `profile-option-${profile}--${id}`;
   const FIELD_ID_UNLISTED = `${FIELD_ID}--unlisted-choice`;
 
   const isActive = selectedProfile?.slug === profile;
-  const setVal = isActive && urlSearchParams["profile"] === selectedProfile.slug;
+  const setVal = isActive && permalinkValues["profile"] === selectedProfile.slug;
 
-  const [value, setValue] = useState((setVal && urlSearchParams[id]) || defaultOption?.value);
-  const [unlistedChoiceValue, setUnlistedChoiceValue] = useState((setVal && urlSearchParams["unlisted_choice"]) || "");
+  const [value, setValue] = useState((setVal && permalinkValues[id]) || defaultOption?.value);
+  const [unlistedChoiceValue, setUnlistedChoiceValue] = useState((setVal && permalinkValues[`${id}:unlisted_choice`]) || "");
 
   if (!(options.length > 0)) {
     return null;
@@ -45,7 +45,7 @@ function ResourceSelect({
 
   if (isActive) {
     setPermalinkValue(id, value);
-    setPermalinkValue("unlisted_choice", unlistedChoiceValue);
+    setPermalinkValue(`${id}:unlisted_choice`, unlistedChoiceValue);
   }
 
   const selectedCustomOption = customOptions.find((opt) => opt.value === value);
@@ -94,6 +94,7 @@ function ResourceSelect({
         <selectedCustomOption.component
           name={FIELD_ID_UNLISTED}
           isActive={isActive}
+          optionKey={id}
         />
       )}
     </>

--- a/src/ResourceSelect.tsx
+++ b/src/ResourceSelect.tsx
@@ -6,6 +6,7 @@ import { IProfileOption } from "./types/config";
 import { ICustomOption } from "./types/fields";
 import Combobox from "./components/form/Combobox";
 import useFormCache from "./hooks/useFormCache";
+import { PermalinkContext } from "./context/Permalink";
 
 interface IResourceSelect {
   id: string;
@@ -27,6 +28,7 @@ function ResourceSelect({
     customOptions,
   );
   const { profile: selectedProfile, urlSearchParams } = useContext(SpawnerFormContext);
+  const { setPermalinkValue } = useContext(PermalinkContext);
   const { getChoiceOptions, removeChoiceOption } = useFormCache();
   const FIELD_ID = `profile-option-${profile}--${id}`;
   const FIELD_ID_UNLISTED = `${FIELD_ID}--unlisted-choice`;
@@ -39,6 +41,11 @@ function ResourceSelect({
 
   if (!(options.length > 0)) {
     return null;
+  }
+
+  if (isActive) {
+    setPermalinkValue(id, value);
+    setPermalinkValue("unlisted_choice", unlistedChoiceValue);
   }
 
   const selectedCustomOption = customOptions.find((opt) => opt.value === value);

--- a/src/ResourceSelect.tsx
+++ b/src/ResourceSelect.tsx
@@ -22,21 +22,20 @@ function ResourceSelect({
 }: IResourceSelect) {
   const { display_name, unlisted_choice } = config;
 
-  const { setCustomOption } = useContext(SpawnerFormContext);
   const { options, defaultOption, hasDefaultChoices } = useSelectOptions(
     config,
     customOptions,
   );
-  const { profile: selectedProfile } = useContext(SpawnerFormContext);
+  const { profile: selectedProfile, urlSearchParams } = useContext(SpawnerFormContext);
   const { getChoiceOptions, removeChoiceOption } = useFormCache();
   const FIELD_ID = `profile-option-${profile}--${id}`;
   const FIELD_ID_UNLISTED = `${FIELD_ID}--unlisted-choice`;
 
   const isActive = selectedProfile?.slug === profile;
-  const [value, setValue] = useState(
-    setCustomOption ? "--extra-selectable-item" : defaultOption?.value,
-  );
-  const [unlistedChoiceValue, setUnlistedChoiceValue] = useState("");
+  const setVal = isActive && urlSearchParams["profile"] === selectedProfile.slug;
+
+  const [value, setValue] = useState((setVal && urlSearchParams[id]) || defaultOption?.value);
+  const [unlistedChoiceValue, setUnlistedChoiceValue] = useState((setVal && urlSearchParams["unlisted_choice"]) || "");
 
   if (!(options.length > 0)) {
     return null;

--- a/src/components/Permalink.tsx
+++ b/src/components/Permalink.tsx
@@ -1,0 +1,26 @@
+import { useContext, useState } from "react";
+import { PermalinkContext } from "../context/Permalink";
+
+function Permalink() {
+  const { copyPermalink } = useContext(PermalinkContext);
+  const [ justCopied, setJustCopied ] = useState<boolean>(false);
+
+  const handleButtonClick = () => {
+    copyPermalink().then(() => {
+      setJustCopied(true);
+      setTimeout(() => setJustCopied(false), 3000);
+    });
+  };
+
+  return (
+    justCopied ? (
+      <div>Copied to clipboard</div>
+    ) : (
+      <button type="button" className="btn btn-link p-0" onClick={handleButtonClick}>
+        Permalink
+      </button>
+    )
+  );
+}
+
+export default Permalink;

--- a/src/context/Permalink.tsx
+++ b/src/context/Permalink.tsx
@@ -2,7 +2,7 @@ import { createContext, PropsWithChildren, useContext } from "react";
 import { SpawnerFormContext } from "../state";
 
 interface IPermalink {
-  copyPermalink: () => void;
+  copyPermalink: () => Promise<void>;
   setPermalinkValue: (key: string, value: string) => void;
 }
 
@@ -34,14 +34,7 @@ export const PermalinkProvider = ({ children }: PropsWithChildren) => {
 
   const copyPermalink = () => {
     const link = `${location.origin}${location.pathname}?${urlParams.toString()}`;
-    navigator.clipboard.writeText(link).then(
-      () => {
-        console.log("Copied", link);
-      },
-      () => {
-        console.log("Error");
-      },
-    );
+    return navigator.clipboard.writeText(link);
   };
 
   const contextValue = {

--- a/src/context/Permalink.tsx
+++ b/src/context/Permalink.tsx
@@ -1,8 +1,9 @@
-import { createContext, PropsWithChildren, useMemo } from "react";
+import { createContext, PropsWithChildren, useMemo, useState } from "react";
 
 type TPermalinkValues = { [key: string]: string }
 
 interface IPermalink {
+  permalinkParseError: boolean;
   permalinkValues: TPermalinkValues;
   copyPermalink: () => Promise<void>;
   setPermalinkValue: (key: string, value: string) => void;
@@ -12,9 +13,25 @@ const queryParamName = "fancy-forms-config";
 
 export const PermalinkContext = createContext<IPermalink>(null);
 export const PermalinkProvider = ({ children }: PropsWithChildren) => {
+  const [permalinkParseError, setPermalinkParseError] = useState<boolean>(false);
+
   const urlParams: TPermalinkValues = useMemo(() => {
-    const params = new URLSearchParams(window.location.search);
-    return JSON.parse(params.get(queryParamName)) || {};
+    let hash = window.location.hash;
+    if (hash.startsWith("#")) {
+      hash = hash.slice(1);
+    }
+    const params = new URLSearchParams(hash);
+
+    const formConfig = params.get(queryParamName);
+    if (formConfig) {
+      try {
+        return JSON.parse(formConfig);
+      } catch (e) {
+        console.error("Error parsing form config", e);
+        setPermalinkParseError(true);
+      }
+    }
+    return {};
   }, []);
 
   const resetParams = () => {
@@ -29,13 +46,14 @@ export const PermalinkProvider = ({ children }: PropsWithChildren) => {
   };
 
   const copyPermalink = () => {
-    const params = new URLSearchParams(location.search);
+    const params = new URLSearchParams();
     params.set(queryParamName, JSON.stringify(urlParams));
-    const link = `${location.origin}${location.pathname}?${params.toString()}`;
+    const link = `${location.origin}${location.pathname}${location.search}#${params.toString()}`;
     return navigator.clipboard.writeText(link);
   };
 
   const contextValue = {
+    permalinkParseError,
     permalinkValues: urlParams,
     setPermalinkValue,
     copyPermalink

--- a/src/context/Permalink.tsx
+++ b/src/context/Permalink.tsx
@@ -8,6 +8,7 @@ interface IPermalink {
 
 const urlParams = new URLSearchParams(location.search);
 const resettableParams = [
+  "binderProvider",
   "binderRepo",
   "ref",
   "unlisted_choice"

--- a/src/context/Permalink.tsx
+++ b/src/context/Permalink.tsx
@@ -48,7 +48,7 @@ export const PermalinkProvider = ({ children }: PropsWithChildren) => {
   const copyPermalink = () => {
     const params = new URLSearchParams();
     params.set(queryParamName, JSON.stringify(urlParams));
-    const link = `${location.origin}${location.pathname}${location.search}#${params.toString()}`;
+    const link = `${location.origin}${location.pathname}${location.search ? location.search : ""}#${params.toString()}`;
     return navigator.clipboard.writeText(link);
   };
 

--- a/src/context/Permalink.tsx
+++ b/src/context/Permalink.tsx
@@ -1,0 +1,57 @@
+import { createContext, PropsWithChildren, useContext } from "react";
+import { SpawnerFormContext } from "../state";
+
+interface IPermalink {
+  copyPermalink: () => void;
+  setPermalinkValue: (key: string, value: string) => void;
+}
+
+const urlParams = new URLSearchParams(location.search);
+const resettableParams = [
+  "binderRepo",
+  "ref",
+  "unlisted_choice"
+];
+
+export const PermalinkContext = createContext<IPermalink>(null);
+export const PermalinkProvider = ({ children }: PropsWithChildren) => {
+  const { profile } = useContext(SpawnerFormContext);
+  const resetParams = () => {
+    const resetFields = [
+      ...resettableParams,
+      ...Object.keys(profile.profile_options)
+    ];
+
+    for (const i in resetFields) {
+      urlParams.delete(resetFields[i]);
+    }
+  };
+
+  const setPermalinkValue = (key: string, value: string) => {
+    urlParams.set(key, value);
+    if (key === "profile") resetParams();
+  };
+
+  const copyPermalink = () => {
+    const link = `${location.origin}${location.pathname}?${urlParams.toString()}`;
+    navigator.clipboard.writeText(link).then(
+      () => {
+        console.log("Copied", link);
+      },
+      () => {
+        console.log("Error");
+      },
+    );
+  };
+
+  const contextValue = {
+    setPermalinkValue,
+    copyPermalink
+  };
+
+  return (
+    <PermalinkContext.Provider value={contextValue}>
+      {children}
+    </PermalinkContext.Provider>
+  );
+};

--- a/src/context/Permalink.tsx
+++ b/src/context/Permalink.tsx
@@ -1,4 +1,4 @@
-import { createContext, PropsWithChildren } from "react";
+import { createContext, PropsWithChildren, useMemo } from "react";
 
 type TPermalinkValues = { [key: string]: string }
 
@@ -10,11 +10,13 @@ interface IPermalink {
 
 const queryParamName = "fancy-forms-config";
 
-const params = new URLSearchParams(location.search);
-const urlParams: TPermalinkValues = JSON.parse(params.get(queryParamName)) || {};
-
 export const PermalinkContext = createContext<IPermalink>(null);
 export const PermalinkProvider = ({ children }: PropsWithChildren) => {
+  const urlParams: TPermalinkValues = useMemo(() => {
+    const params = new URLSearchParams(window.location.search);
+    return JSON.parse(params.get(queryParamName)) || {};
+  }, []);
+
   const resetParams = () => {
     for (const key of Object.keys(urlParams)) {
       delete urlParams[key];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,12 +2,15 @@ import { createRoot } from "react-dom/client";
 import { SpawnerFormProvider } from "./state";
 import Form from "./ProfileForm";
 import { FormCacheProvider } from "./context/FormCache";
+import { PermalinkProvider } from "./context/Permalink";
 
 const root = createRoot(document.getElementById("form"));
 root.render(
   <SpawnerFormProvider>
     <FormCacheProvider>
-      <Form />
+      <PermalinkProvider>
+        <Form />
+      </PermalinkProvider>
     </FormCacheProvider>
   </SpawnerFormProvider>,
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,11 +6,11 @@ import { PermalinkProvider } from "./context/Permalink";
 
 const root = createRoot(document.getElementById("form"));
 root.render(
-  <SpawnerFormProvider>
-    <FormCacheProvider>
-      <PermalinkProvider>
+  <PermalinkProvider>
+    <SpawnerFormProvider>
+      <FormCacheProvider>
         <Form />
-      </PermalinkProvider>
-    </FormCacheProvider>
-  </SpawnerFormProvider>,
+      </FormCacheProvider>
+    </SpawnerFormProvider>,
+  </PermalinkProvider>
 );

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -1,11 +1,9 @@
 import {
   createContext,
   PropsWithChildren,
-  useEffect,
   useMemo,
   useState,
 } from "react";
-import { hasDynamicImageBuilding } from "./utils";
 import {
   IJupytherHubWindowObject,
   IProfile,
@@ -16,71 +14,33 @@ interface ISpawnerFormContext {
   profileList: IProfile[];
   profile: IProfile;
   setProfile: React.Dispatch<React.SetStateAction<string>>;
-  binderProvider: string;
-  binderRepo: string;
-  ref: string;
-  paramsError: string;
-  setCustomOption: boolean;
+  urlSearchParams: ISearchParams;
 }
 
 export const SpawnerFormContext = createContext<ISpawnerFormContext>(null);
 
-function isDynamicImageProfile(profile: IProfile) {
-  const { profile_options } = profile;
-
-  if (!profile_options) return false;
-
-  return Object.entries(profile_options).some(([key, option]) =>
-    hasDynamicImageBuilding(key, option),
-  );
-}
-
 export const SpawnerFormProvider = ({ children }: PropsWithChildren) => {
+  const urlSearchParams = new Proxy(new URLSearchParams(window.location.search), {
+    get: (searchParams: URLSearchParams, prop: string) =>
+      searchParams.get(prop),
+  }) as unknown as ISearchParams;
+
+  const { profile: profileParam } = urlSearchParams;
+
   const profileList = (window as IJupytherHubWindowObject).profileList;
   const defaultProfile =
     profileList.find((profile) => profile.default === true) || profileList[0];
-  const [selectedProfile, setProfile] = useState(defaultProfile.slug);
+  const [selectedProfile, setProfile] = useState(profileParam || defaultProfile.slug);
 
   const profile = useMemo(() => {
     return profileList.find(({ slug }) => slug === selectedProfile);
   }, [selectedProfile]);
 
-  const params = new Proxy(new URLSearchParams(window.location.search), {
-    get: (searchParams: URLSearchParams, prop: string) =>
-      searchParams.get(prop),
-  });
-  const { binderProvider, binderRepo, ref } = params as ISearchParams;
-
-  const paramsError = useMemo(() => {
-    if (binderProvider && binderRepo && ref) {
-      const profilesWithDynamicImageBuilding = profileList.filter(
-        isDynamicImageProfile,
-      );
-
-      if (profilesWithDynamicImageBuilding.length > 1) {
-        return "Unable to pre-select dynamic image building.";
-      }
-    }
-  }, [binderProvider, binderRepo, ref]);
-
-  const setCustomOption = binderProvider && binderRepo && ref && !paramsError;
-
-  useEffect(() => {
-    if (setCustomOption) {
-      const dynamicImageProfile = profileList.find(isDynamicImageProfile);
-      setProfile(dynamicImageProfile.slug);
-    }
-  }, [setCustomOption]);
-
   const value = {
     profileList,
     profile,
     setProfile,
-    binderProvider,
-    binderRepo,
-    ref,
-    paramsError,
-    setCustomOption,
+    urlSearchParams
   };
 
   return (

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -1,31 +1,32 @@
 import {
   createContext,
   PropsWithChildren,
+  useContext,
   useMemo,
   useState,
 } from "react";
 import {
   IJupytherHubWindowObject,
   IProfile,
-  ISearchParams,
 } from "./types/config";
+import { PermalinkContext } from "./context/Permalink";
 
 interface ISpawnerFormContext {
   profileList: IProfile[];
   profile: IProfile;
   setProfile: React.Dispatch<React.SetStateAction<string>>;
-  urlSearchParams: ISearchParams;
+  // urlSearchParams: ISearchParams;
 }
 
 export const SpawnerFormContext = createContext<ISpawnerFormContext>(null);
 
 export const SpawnerFormProvider = ({ children }: PropsWithChildren) => {
-  const urlSearchParams = new Proxy(new URLSearchParams(window.location.search), {
-    get: (searchParams: URLSearchParams, prop: string) =>
-      searchParams.get(prop),
-  }) as unknown as ISearchParams;
-
-  const { profile: profileParam } = urlSearchParams;
+  // const urlSearchParams = new Proxy(new URLSearchParams(window.location.search), {
+  //   get: (searchParams: URLSearchParams, prop: string) =>
+  //     searchParams.get(prop),
+  // }) as unknown as ISearchParams;
+  const { permalinkValues } = useContext(PermalinkContext);
+  const profileParam = permalinkValues["profile"];
 
   const profileList = (window as IJupytherHubWindowObject).profileList;
   const defaultProfile =
@@ -39,8 +40,7 @@ export const SpawnerFormProvider = ({ children }: PropsWithChildren) => {
   const value = {
     profileList,
     profile,
-    setProfile,
-    urlSearchParams
+    setProfile
   };
 
   return (

--- a/src/test/renderWithContext.tsx
+++ b/src/test/renderWithContext.tsx
@@ -1,0 +1,19 @@
+import { render } from "@testing-library/react";
+
+import { SpawnerFormProvider } from "../state";
+import { FormCacheProvider } from "../context/FormCache";
+import { PermalinkProvider } from "../context/Permalink";
+
+function renderWithContext(children: React.ReactNode) {
+  return render(
+    <PermalinkProvider>
+      <SpawnerFormProvider>
+        <FormCacheProvider>
+          {children}
+        </FormCacheProvider>
+      </SpawnerFormProvider>
+    </PermalinkProvider>
+  );
+}
+
+export default renderWithContext;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -50,7 +50,9 @@ export type IJupytherHubWindowObject = Window &
   };
 
 export interface ISearchParams {
+  profile?: string;
   binderProvider?: string;
   binderRepo?: string;
   ref?: string;
+  [key: string]: string;
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -48,11 +48,3 @@ export type IJupytherHubWindowObject = Window &
   typeof globalThis & {
     profileList: IProfile[];
   };
-
-export interface ISearchParams {
-  profile?: string;
-  binderProvider?: string;
-  binderRepo?: string;
-  ref?: string;
-  [key: string]: string;
-}

--- a/src/types/fields.ts
+++ b/src/types/fields.ts
@@ -8,6 +8,7 @@ export interface SelectOption {
 export interface ICustomOptionProps {
   name: string;
   isActive: boolean;
+  optionKey: string;
 }
 
 export interface ICustomOption {


### PR DESCRIPTION
Resolves #109 Implements reading URL parameters and filling form.

Currently we're supporting:

- `profile` to select the profile
- `unlisted_choice` to fill the unlisted choice field in the profile
- `binderRepo`, `ref` and `binderProvider` to profile image-build options, which we already supported
- Plus, any key-value combination that is specified in the Jupytherhub config

To test, try the following:

- **Select image and resource** http://localhost:8000/hub/spawn?profile=gpu-only-usage&image=pangeo&resources=mem_10_8
- **Select custom docker image** http://localhost:8000/hub/spawn?profile=gpu-only-usage&image=unlisted_choice&resources=mem_10_8&unlisted_choice=my:image
- **Select build image and prefull repo parameters** http://localhost:8000/hub/spawn?profile=gpu-only-usage&image=--extra-selectable-item&resources=mem_10_8&ref=main&binderRepo=org/repo
