### PR TITLE
Set select menu height

### DIFF
--- a/src/components/form/CustomSelect.tsx
+++ b/src/components/form/CustomSelect.tsx
@@ -47,6 +47,7 @@ export function CustomizedSelect({
   return (
     <Select
       options={options}
+      maxMenuHeight={300}
       formatOptionLabel={(option, meta) => {
         const classNames = ["react-select-item-container"];
         if (meta.selectValue[0].value === option.value) {


### PR DESCRIPTION
Fixes #128

Setting the maximum height for the select menu forces select to show a scrollbar of the items exceed the height.